### PR TITLE
v2.1.0

### DIFF
--- a/ActionBarsEnhanced.toc
+++ b/ActionBarsEnhanced.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFActionBars Enhanced|r (Retail | Beta)
 ## IconTexture: Interface\AddOns\ActionBarsEnhanced\assets\icon
 ## Category: Action Bars
-## Version: 2.0.1
+## Version: 2.1.0
 ## SavedVariables: ABDB
 ## Notes: Enhance Blizzard Action Bars
 ## Notes-ruRU: Улучшение стандартных панелей заклинаний
@@ -21,6 +21,7 @@ SharedMedia\RegisterMedia.lua
 constants.lua
 layout.lua
 config.lua
+LayoutGrid\LayoutGrid.lua
 frames\ActionBarsEnhanced.xml
 ActionBarsEnhanced_Options.lua
 frames\ProfileImportExport.xml

--- a/ActionBarsEnhanced_AdvancedMenu.lua
+++ b/ActionBarsEnhanced_AdvancedMenu.lua
@@ -6,21 +6,7 @@ local T = Addon.Templates
 local RightClickAtlasMarkup = CreateAtlasMarkup('NPE_RightClick', 18, 18);
 local LeftClickAtlasMarkup = CreateAtlasMarkup('NPE_LeftClick', 18, 18);
 
-local ActionBarNames = {
-    "GlobalSettings",
-    "MainActionBar",
-    "MultiBarBottomLeft",
-    "MultiBarBottomRight",
-    "MultiBarRight",
-    "MultiBarLeft",
-    "MultiBar5",
-    "MultiBar6",
-    "MultiBar7",
-    "PetActionBar",
-    "StanceBar",
-    "BagsBar",
-    "MicroMenu",
-}
+local ActionBarNames = Addon.ActionBarNames
 local miniBars = {
     "PetActionBar",
     "StanceBar",
@@ -29,12 +15,7 @@ local microBars = {
     "BagsBar",
     "MicroMenu",
 }
-local CDMFrames = {
-    "EssentialCooldownViewer",
-    "UtilityCooldownViewer",
-    "BuffIconCooldownViewer",
-    "BuffBarCooldownViewer",
-}
+local CDMFrames = Addon.CDMFrames
 
 local menuList = {
     {
@@ -78,7 +59,7 @@ for _, element in ipairs(menuList) do
                 label = frame,
                 name = L[frame] or frame,
                 category = 1,
-                layout = frame == "BuffBarCooldownViewer" and "BuffBarCooldownViewer" or "EssentialCooldownViewer"
+                layout = frame ~= "UtilityCooldownViewer" and frame or "EssentialCooldownViewer"
             })
         end
     elseif element.name == "Something Else" then
@@ -153,13 +134,9 @@ ABE_BarsButtonMixin = {}
 
 function ABE_BarsButtonMixin:SetSelected(selected)
     local bar = ABE_BarsListMixin.label ~= "GlobalSettings" and _G[ABE_BarsListMixin.label] or nil
-    --local cdm = tContains(CDMFrames, ABE_BarsListMixin.label)
 
     if selected then
 		self.Texture:Show()
-        --[[ if cdm then
-            bar:SetIsEditing(not bar:IsEditing())
-        end ]]
         if bar then
             ABE_BarsFrameMixin.selection:SetParent(bar)
             ABE_BarsFrameMixin.selection:SetPoint("TOPLEFT", bar, "TOPLEFT", -4, 4)
@@ -176,10 +153,6 @@ function ABE_BarsButtonMixin:SetSelected(selected)
             ABE_BarsFrameMixin.selection:Hide()
             ABE_BarsFrameMixin.selection.PulseAnim:Stop()
         end
-        --[[ if cdm then
-            bar:SetIsEditing(not bar:IsEditing())
-            bar:Layout()
-        end ]]
 		self.Texture:Hide()
 	end
 end

--- a/CooldownManagerSettings.lua
+++ b/CooldownManagerSettings.lua
@@ -84,23 +84,22 @@ local function Hook_CooldownViewerSettingsBar(self)
     for i, item in ipairs(activeItems) do
         local barName = item.Bar.Name:GetText()
         if barName then
+            if item.__colorSwatch then
+                Addon.CooldownViewerSwatchPool:Release(item.__colorSwatch)
+                item.__colorSwatch = nil
+            end
             if not item.Icon:IsDesaturated() then
                 index = index + 1
                 item.Bar.Name:SetText("["..index.."]: "..barName)
                 local savedColor = Addon:GetValue("BuffBar"..index, nil, "BuffBarCooldownViewer") or { r = 1, g = 1, b = 1, a = 1 }
                 item.__color = savedColor
 
-                if not item.__colorSwatch then
-                    SetupColorSwatchOnItem(item, index)
-                end
+                SetupColorSwatchOnItem(item, index)
+
                 item.__colorSwatch:SetColorRGB(item.__color.r, item.__color.g, item.__color.b)
                 item.Bar.FillTexture:SetVertexColor(item.__color.r, item.__color.g, item.__color.b, item.__color.a)
             else
-                if item.__colorSwatch then
-                    Addon.CooldownViewerSwatchPool:Release(item.__colorSwatch)
-                    item.__colorSwatch = nil
-                    item.Bar.FillTexture:SetVertexColor(1, 1, 1, 1)
-                end
+                item.Bar.FillTexture:SetVertexColor(1, 1, 1, 1)
             end
         end
     end

--- a/LayoutGrid/LayoutGrid.lua
+++ b/LayoutGrid/LayoutGrid.lua
@@ -1,0 +1,202 @@
+local AddonName, Addon = ...
+
+function Addon:ApplyActionBarsCenteredGrid(self, layoutChildren, stride, padding)
+    if #layoutChildren == 0 then return end
+
+    stride = math.min(stride, #layoutChildren)
+
+    local firstChild = layoutChildren[1]
+    local width = firstChild:GetWidth()
+    local height = firstChild:GetHeight()
+
+    if width == 0 or height == 0 then
+        width, height = 36, 36
+    end
+
+    local spacing = padding
+    local addButtonsToRight = self.addButtonsToRight
+    local addButtonsToTop = self.addButtonsToTop
+
+    local anchorPoint
+    if addButtonsToTop then
+        anchorPoint = addButtonsToRight and "BOTTOMLEFT" or "BOTTOMRIGHT"
+    else
+        anchorPoint = addButtonsToRight and "TOPLEFT" or "TOPRIGHT"
+    end
+
+    if self.isHorizontal then
+        local itemStep = width + spacing
+        local rowStep = height + spacing
+        local fullRowWidth = (stride * width) + ((stride - 1) * spacing)
+        local numRows = math.ceil(#layoutChildren / stride)
+
+        for rowIndex = 0, numRows - 1 do
+            local rowStart = rowIndex * stride + 1
+            local rowEnd = math.min(rowStart + stride - 1, #layoutChildren)
+            local itemCount = rowEnd - rowStart + 1
+
+            local actualRowWidth = (itemCount * width) + ((itemCount - 1) * spacing)
+            local xOffsetForRow = (fullRowWidth - actualRowWidth) / 2
+            
+            local yOffset = rowIndex * rowStep
+
+            for i = rowStart, rowEnd do
+                local child = layoutChildren[i]
+                local itemIndex = i - rowStart
+                local xOffset = xOffsetForRow + itemIndex * itemStep
+
+                local finalX = addButtonsToRight and xOffset or -xOffset
+                
+                local finalY
+                if addButtonsToTop then
+                    finalY = yOffset
+                else
+                    finalY = -yOffset
+                end
+                child:ClearAllPoints()
+                child:SetPoint(anchorPoint, self, anchorPoint, finalX, finalY)
+            end
+        end
+
+        local totalWidth = (stride * width) + ((stride - 1) * spacing)
+        local totalHeight = (numRows * height) + ((numRows - 1) * spacing)
+        self:SetSize(totalWidth, totalHeight)
+        
+    else
+        local itemStep = height + spacing
+        local colStep = width + spacing
+        local maxRows = stride
+        local numCols = math.ceil(#layoutChildren / maxRows)
+        local fullColHeight = (maxRows * height) + ((maxRows - 1) * spacing)
+
+        for colIndex = 0, numCols - 1 do
+            local colStart = colIndex * maxRows + 1
+            local colEnd = math.min(colStart + maxRows - 1, #layoutChildren)
+            local itemCount = colEnd - colStart + 1
+
+            local actualColHeight = (itemCount * height) + ((itemCount - 1) * spacing)
+            local yOffsetForCol = (fullColHeight - actualColHeight) / 2
+            local xOffset = colIndex * colStep
+
+            for i = colStart, colEnd do
+                local child = layoutChildren[i]
+                local itemIndex = i - colStart
+                local yOffset = yOffsetForCol + itemIndex * itemStep
+
+                local finalX = addButtonsToRight and xOffset or -xOffset
+                local finalY = addButtonsToTop and yOffset or -yOffset
+
+                child:ClearAllPoints()
+                child:SetPoint(anchorPoint, self, anchorPoint, finalX, finalY)
+            end
+        end
+
+        local totalWidth = (numCols * width) + ((numCols - 1) * spacing)
+        local totalHeight = (maxRows * height) + ((maxRows - 1) * spacing)
+        self:SetSize(totalWidth, totalHeight)
+    end
+end
+
+function Addon:ApplyStandardGridLayout(self, layoutChildren, stride, padding)
+    if #layoutChildren == 0 then return end
+
+    local layoutFramesGoingUp = self.__layoutFramesGoingUp or self.layoutFramesGoingUp
+
+    local xMultiplier = self.layoutFramesGoingRight and 1 or -1
+    local yMultiplier = layoutFramesGoingUp and 1 or -1
+
+    local layout
+    if self.isHorizontal then
+        layout = GridLayoutUtil.CreateStandardGridLayout(stride, padding, padding, xMultiplier, yMultiplier)
+    else
+        layout = GridLayoutUtil.CreateVerticalGridLayout(stride, padding, padding, xMultiplier, yMultiplier)
+    end
+
+    local anchorPoint
+    if layoutFramesGoingUp then
+        anchorPoint = self.layoutFramesGoingRight and "BOTTOMLEFT" or "BOTTOMRIGHT"
+    else
+        anchorPoint = self.layoutFramesGoingRight and "TOPLEFT" or "TOPRIGHT"
+    end
+    GridLayoutUtil.ApplyGridLayout(layoutChildren, AnchorUtil.CreateAnchor(anchorPoint, self, anchorPoint), layout) 
+end
+
+function Addon:ApplyCenteredGridLayout(self, layoutChildren, stride, padding)
+    if #layoutChildren == 0 then return end
+
+    stride = math.min(stride, #layoutChildren)
+
+    local firstChild = layoutChildren[1]
+    local width = firstChild:GetWidth()
+    local height = firstChild:GetHeight()
+
+    if width == 0 or height == 0 then
+        width, height = 36, 36
+    end
+
+    local spacing = padding
+    local layoutFramesGoingRight = self.layoutFramesGoingRight ~= false
+    local layoutFramesGoingUp =  (self.__layoutFramesGoingUp or self.layoutFramesGoingUp) == true
+
+    local anchorPoint
+    if layoutFramesGoingUp then
+        anchorPoint = layoutFramesGoingRight and "BOTTOMLEFT" or "BOTTOMRIGHT"
+    else
+        anchorPoint = layoutFramesGoingRight and "TOPLEFT" or "TOPRIGHT"
+    end
+
+    if self.isHorizontal then
+        local itemStep = width + spacing
+        local rowStep = height + spacing
+        local xMultiplier = layoutFramesGoingRight and 1 or -1
+        local yMultiplier = layoutFramesGoingUp and 1 or -1
+
+        local fullRowWidth = (stride * width) + ((stride - 1) * spacing)
+        local numRows = math.ceil(#layoutChildren / stride)
+
+        for rowIndex = 0, numRows - 1 do
+            local rowStart = rowIndex * stride + 1
+            local rowEnd = math.min(rowStart + stride - 1, #layoutChildren)
+            local itemCount = rowEnd - rowStart + 1
+
+            local actualRowWidth = (itemCount * width) + ((itemCount - 1) * spacing)
+            local xOffsetForRow = (fullRowWidth - actualRowWidth) / 2
+            local yOffset = rowIndex * rowStep
+
+            for i = rowStart, rowEnd do
+                local child = layoutChildren[i]
+                local itemIndex = i - rowStart
+                local xOffset = xOffsetForRow + itemIndex * itemStep
+
+                child:SetPoint(anchorPoint, self, anchorPoint, xOffset * xMultiplier, yOffset * yMultiplier)
+            end
+        end
+    else
+        local itemStep = height + spacing
+        local colStep = width + spacing
+        local xMultiplier = layoutFramesGoingRight and 1 or -1
+        local yMultiplier = layoutFramesGoingUp and 1 or -1
+
+        local maxRows = stride
+        local numCols = math.ceil(#layoutChildren / maxRows)
+        local fullColHeight = (maxRows * height) + ((maxRows - 1) * spacing)
+
+        for colIndex = 0, numCols - 1 do
+            local colStart = colIndex * maxRows + 1
+            local colEnd = math.min(colStart + maxRows - 1, #layoutChildren)
+            local itemCount = colEnd - colStart + 1
+
+            local actualColHeight = (itemCount * height) + ((itemCount - 1) * spacing)
+            local yOffsetForCol = (fullColHeight - actualColHeight) / 2
+            local xOffset = colIndex * colStep
+
+            for i = colStart, colEnd do
+                local child = layoutChildren[i]
+                local itemIndex = i - colStart
+                local yOffset = yOffsetForCol + itemIndex * itemStep
+
+                child:SetPoint(anchorPoint, self, anchorPoint, xOffset * xMultiplier, yOffset * yMultiplier)
+            end
+        end
+    end
+end

--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -119,6 +119,10 @@ L.CustomColorOOR = "Custom color for Out Of Range"
 L.CustomColorOOM = "Custom color for Out Of Mana"
 L.CustomColorNoUse = "Custom color for Not Usable spells"
 
+L.CustomColorGCD = "Custom color for icon On GCD"
+L.CustomColorCD = "Custom color for icon On CD"
+L.CustomColorNormal = "Custom color for Normal state"
+
 L.RemoveOORColor = "Remove OOR Color"
 L.RemoveOOMColor = "Remove OOM Color" 
 L.RemoveNUColor = "Remove NU Color"
@@ -220,6 +224,7 @@ L.CDMBackdropColor = "Border Color"
 L.CDMBackdropAuraColor = "Aura Border Color"
 L.CDMBackdropPandemicColor = "Pandemic Border Color"
 L.CDMReverseSwipe = "Reverse Cooldown Fill"
+L.CDMRemoveAuraTypeBorder = "Remove Aura type border"
 
 -- ==========================================
 -- Status Bar Settings
@@ -251,8 +256,8 @@ L.CDMAuraReverseSwipe = "Reverse Aura Fill"
 L.CDMCooldownTitle = "Cooldown Customization"
 L.CDMCooldownDesc = "Modify cooldown appearance for CDM"
 
-L.BackdropTitle = "Icon Frame"
-L.BackdropDesc = "Create and configure new frame for rendering icon border"
+L.IconBorderTitle = "Icon Frame"
+L.IconBorderDesc = "Create and configure new frame for rendering icon border"
 
 L.CDMOptionsTitle = "Additional CDM Options"
 L.CDMOptionsDesc = "Global enable additional settings that override standard CDM parameters"

--- a/Locales/ruRU.lua
+++ b/Locales/ruRU.lua
@@ -121,11 +121,14 @@ L.CustomColorCooldownSwipe = "Использовать свой цвет для 
 L.CustomColorOOR = "Свой цвет Out Of Range"
 L.CustomColorOOM = "Свой цвет Out Of Mana"
 L.CustomColorNoUse = "Свой цвет если кнопка недоступна"
+L.CustomColorGCD = "Свой цвет если спелл на ГКД"
+L.CustomColorCD = "Свой цвет если спелл на КД"
+L.CustomColorNormal = "Свой цвет для обычного состояния"
 
 L.RemoveOORColor = "Убрать цвет OOR"
 L.RemoveOOMColor = "Убрать цвет OOM"
 L.RemoveNUColor = "Убрать цвет NU"
-L.RemoveDesaturation = "Убрать десатурацию"
+L.RemoveDesaturation = "Убрать обесцвечивание"
 
 -- ==========================================
 -- Hide Frames and Animations
@@ -223,6 +226,7 @@ L.CDMBackdropColor = "Цвет рамки"
 L.CDMBackdropAuraColor = "Цвет рамки для ауры"
 L.CDMBackdropPandemicColor = "Цвет рамки для пандемика"
 L.CDMReverseSwipe = "Обратное заполнение кулдауна"
+L.CDMRemoveAuraTypeBorder = "Убрать рамку типа Ауры"
 
 -- ==========================================
 -- Status Bar Settings
@@ -254,8 +258,8 @@ L.CDMAuraReverseSwipe = "Обратное заполнение ауры"
 L.CDMCooldownTitle = "Кастомизация кулдауна"
 L.CDMCooldownDesc = "Изменить внешний вид кулдауна для CDM."
 
-L.BackdropTitle = "Рамка иконки"
-L.BackdropDesc = "Создание и настройка нового фрейма для отрисовки рамки вокруг иконки."
+L.IconBorderTitle = "Рамка иконки"
+L.IconBorderDesc = "Создание и настройка нового фрейма для отрисовки рамки вокруг иконки."
 
 L.CDMOptionsTitle = "Дополнительные настройки CDM"
 L.CDMOptionsDesc = "Глобальное включение дополнительных настроек, перезаписывающих стандартные параметры CDM."

--- a/config.lua
+++ b/config.lua
@@ -501,6 +501,27 @@ Addon.config.containers = {
                 checkboxValues  = {"UseNoUseColor", "NoUseDesaturate"},
                 alpha           = false,
             },
+            ["CustomColorOnGCD"] = {
+                type            = "colorSwatch",
+                name            = L.CustomColorGCD,
+                value           = "GCDColor",
+                checkboxValues  = {"UseGCDColor", "GCDColorDesaturate"},
+                alpha           = false,
+            },
+            ["CustomColorOnActualCD"] = {
+                type            = "colorSwatch",
+                name            = L.CustomColorCD,
+                value           = "CDColor",
+                checkboxValues  = {"UseCDColor", "CDColorDesaturate"},
+                alpha           = false,
+            },
+            ["CustomColorOnNormal"] = {
+                type            = "colorSwatch",
+                name            = L.CustomColorNormal,
+                value           = "NormalColor",
+                checkboxValues  = {"UseNormalColor", "NormalColorDesaturate"},
+                alpha           = false,
+            },
         }
     },
     HideFramesOptionsContainer = {
@@ -875,7 +896,13 @@ Addon.config.containers = {
                 step            = 1,
                 sliderName      = {top = "Rows"},
                 callback        = function()
-                    Addon:RefreshButtons()
+                    local frameName = ABE_BarsListMixin:GetActionBar()
+                    if frameName == "GlobalSettings" then
+                        Addon:UpdateAllActionBarGrid()
+                    else
+                        local frame = _G[frameName]
+                        Addon:UpdateActionBarGrid(frame)
+                    end
                 end,
             },
             ["ColumnsNumber"] = {
@@ -888,7 +915,13 @@ Addon.config.containers = {
                 step            = 1,
                 sliderName      = {top = "Columns"},
                 callback        = function()
-                    Addon:RefreshButtons()
+                    local frameName = ABE_BarsListMixin:GetActionBar()
+                    if frameName == "GlobalSettings" then
+                        Addon:UpdateAllActionBarGrid()
+                    else
+                        local frame = _G[frameName]
+                        Addon:UpdateActionBarGrid(frame)
+                    end
                 end,
             },
             ["ButtonsNumber"] = {
@@ -901,7 +934,13 @@ Addon.config.containers = {
                 step            = 1,
                 sliderName      = {top = "Buttons"},
                 callback        = function()
-                    Addon:RefreshButtons()
+                    local frameName = ABE_BarsListMixin:GetActionBar()
+                    if frameName == "GlobalSettings" then
+                        Addon:UpdateAllActionBarGrid()
+                    else
+                        local frame = _G[frameName]
+                        Addon:UpdateActionBarGrid(frame)
+                    end
                 end,
             },
             ["BarsPadding"] = {
@@ -913,7 +952,15 @@ Addon.config.containers = {
                 max             = 50,
                 step            = 1,
                 sliderName      = {top = "Padding"},
-                callback        = function() Addon:RefreshButtons() end,
+                callback        = function()
+                    local frameName = ABE_BarsListMixin:GetActionBar()
+                    if frameName == "GlobalSettings" then
+                        Addon:UpdateAllActionBarGrid()
+                    else
+                        local frame = _G[frameName]
+                        Addon:UpdateActionBarGrid(frame)
+                    end
+                end,
             },
             ["ButtonSize"] = {
                 type            = "checkboxSlider",
@@ -925,6 +972,38 @@ Addon.config.containers = {
                 step            = 1,
                 sliderName      = {{top = "size X"}, {top = "size Y"}},
                 callback        = function() Addon:RefreshButtons() end,
+            },
+            ["CenteredGrid"] = {
+                type            = "checkbox",
+                name            = L.CDMCenteredGrid,
+                value           = "GridCentered",
+                callback        = function()
+                    local frameName = ABE_BarsListMixin:GetActionBar()
+                    if frameName == "GlobalSettings" then
+                        Addon:UpdateAllActionBarGrid()
+                    else
+                        local frame = _G[frameName]
+                        Addon:UpdateActionBarGrid(frame)
+                    end
+                end,
+            },
+            ["BarGrow"] = {
+                type        = "dropdown",
+                setting     = Addon.BarsVerticalGrow,
+                name        = L.BarGrow,
+                IsSelected  = function(id) return id == Addon:GetValue("CurrentBarGrow", nil, true) end,
+                OnSelect    = function(id) Addon:SaveSetting("CurrentBarGrow", id, true) end,
+                showNew     = false,
+                OnEnter     = false,
+                callback        = function()
+                    local frameName = ABE_BarsListMixin:GetActionBar()
+                    if frameName == "GlobalSettings" then
+                        Addon:UpdateAllActionBarGrid()
+                    else
+                        local frame = _G[frameName]
+                        Addon:UpdateActionBarGrid(frame)
+                    end
+                end,
             },
         }
     },
@@ -954,7 +1033,7 @@ Addon.config.containers = {
                 min             = 10,
                 max             = 80,
                 step            = 1,
-                sliderName      = {top = "Size X"},
+                sliderName      = {top = "Size"},
                 callback        = function()
                     local frameName = ABE_BarsListMixin:GetActionBar()
                     CooldownManagerEnhanced:ForceUpdate(frameName)
@@ -1251,8 +1330,8 @@ Addon.config.containers = {
         }
     },
     CooldownViewerBackdropContainer = {
-        title = L.BackdropTitle,
-        desc = L.BackdropDesc,
+        title = L.IconBorderTitle,
+        desc = L.IconBorderDesc,
         childs = {
             ["BackdropSize"] = {
                 type            = "checkboxSlider",
@@ -1404,8 +1483,8 @@ Addon.config.containers = {
                 type        = "dropdown",
                 setting     = Addon.BarsVerticalGrow,
                 name        = L.BarGrow,
-                IsSelected  = function(id) return id == Addon:GetValue("CurrentCDMBarGrow", nil, true) end,
-                OnSelect    = function(id) Addon:SaveSetting("CurrentCDMBarGrow", id, true) end,
+                IsSelected  = function(id) return id == Addon:GetValue("CurrentBarGrow", nil, true) end,
+                OnSelect    = function(id) Addon:SaveSetting("CurrentBarGrow", id, true) end,
                 showNew     = false,
                 OnEnter     = false,
                 OnClose     = function()
@@ -1469,12 +1548,11 @@ Addon.config.containers = {
             ["CenteredGrid"] = {
                 type            = "checkbox",
                 name            = L.CDMCenteredGrid,
-                value           = "CDMCentered",
+                value           = "GridCentered",
                 callback        = function()
                     local frameName = ABE_BarsListMixin:GetActionBar()
                     CooldownManagerEnhanced:ForceUpdate(frameName)
                 end,
-                
             },
             ["RemoveIconMask"] = {
                 type            = "checkbox",
@@ -1489,6 +1567,15 @@ Addon.config.containers = {
                 type            = "checkbox",
                 name            = L.CDMRemovePandemic,
                 value           = "CDMRemovePandemic",
+                callback        = function()
+                    local frameName = ABE_BarsListMixin:GetActionBar()
+                    CooldownManagerEnhanced:ForceUpdate(frameName)
+                end,
+            },
+            ["RemoveAuraTypeBorder"] = {
+                type            = "checkbox",
+                name            = L.CDMRemoveAuraTypeBorder,
+                value           = "CDMRemoveAuraTypeBorder",
                 callback        = function()
                     local frameName = ABE_BarsListMixin:GetActionBar()
                     CooldownManagerEnhanced:ForceUpdate(frameName)
@@ -1521,6 +1608,7 @@ Addon.config.containers = {
                 showNew     = false,
                 OnEnter     = false,
                 OnClose     = function()
+                    ActionBarEnhancedDropdownMixin:RefreshAllPreview()
                     local frameName = ABE_BarsListMixin:GetActionBar()
                     CooldownManagerEnhanced:ForceUpdate(frameName)
                 end,
@@ -1535,6 +1623,7 @@ Addon.config.containers = {
                 step            = 0.01,
                 sliderName      = {top = "Mask Scale"},
                 callback        = function()
+                    ActionBarEnhancedDropdownMixin:RefreshAllPreview()
                     local frameName = ABE_BarsListMixin:GetActionBar()
                     CooldownManagerEnhanced:ForceUpdate(frameName)
                 end,
@@ -1549,6 +1638,7 @@ Addon.config.containers = {
                 step            = 0.01,
                 sliderName      = {top = "Icon Scale"},
                 callback        = function()
+                    ActionBarEnhancedDropdownMixin:RefreshAllPreview()
                     local frameName = ABE_BarsListMixin:GetActionBar()
                     CooldownManagerEnhanced:ForceUpdate(frameName)
                 end,

--- a/constants.lua
+++ b/constants.lua
@@ -109,6 +109,18 @@ Addon.Defaults = {
     NoUseDesaturate = true,
     NoUseColor = { r=0.6, g=0.6, b=0.6, a=1.0 },
 
+    UseGCDColor = false,
+    GCDColorDesaturate = false,
+    GCDColor = { r=1.0, g=1.0, b=1.0, a=1.0 },
+
+    UseCDColor = false,
+    CDColorDesaturate = false,
+    CDColor = { r=0.7, g=0.7, b=0.7, a=1.0 },
+
+    UseNormalColor = false,
+    NormalColorDesaturate = false,
+    NormalColor = { r=1.0, g=1.0, b=1.0, a=1.0 },
+
     HideBagsBar = false,
     HideMicroMenu = false,
     HideStanceBar = false,
@@ -219,7 +231,7 @@ Addon.Defaults = {
     UseCDMBackdrop = false,
     CDMBackdropSize = 1,
 
-    CDMCentered = false,
+    GridCentered = false,
     CDMRemoveIconMask = false,
     CDMRemovePandemic = false,
 
@@ -267,7 +279,7 @@ Addon.Defaults = {
     UseCDMBarBGColor = true,
     CDMBarBGColor = { r=0.0, g=0.0, b=0.0, a=0.5 },
 
-    CurrentCDMBarGrow = 2,
+    CurrentBarGrow = 2,
 
     UseCDMBarIconSize = false,
     CDMBarIconSize = 30,
@@ -306,6 +318,8 @@ Addon.Defaults = {
     CDMItemSize = 40,
 
     CDMRemoveGCDSwipe = false,
+
+    CDMRemoveAuraTypeBorder = false,
 
 }
 

--- a/layout.lua
+++ b/layout.lua
@@ -294,15 +294,23 @@ Addon.layout = {
             {name = "PreviewFont05", template = "OptionsButtonTextPreviewTemplate", point = {"TOP", "PreviewFont075", "BOTTOM", 0, -5}, scale="0.5"},
         }
     },
-    --[[ {
+    {
         name = "BarsOptionsContainer",
         childs = {
-            {name = "BarOrientation", template = "OptionsDropdownTemplate"},
-            {name = "RowsNumber", template = "OptionsCheckboxSliderTemplate"},
-            {name = "ColumnsNumber", template = "OptionsCheckboxSliderTemplate"},
-            {name = "ButtonsNumber", template = "OptionsCheckboxSliderTemplate"},
-            {name = "ButtonSize", template = "OptionsDoubleCheckboxSliderTemplate"},
+            --{name = "BarOrientation", template = "OptionsDropdownTemplate"},
+            {name = "BarGrow", template = "OptionsDropdownTemplate"},
+            {name = "CenteredGrid", template = "OptionsCheckboxTemplate"},
+            --{name = "RowsNumber", template = "OptionsCheckboxSliderTemplate"},
+            --{name = "ColumnsNumber", template = "OptionsCheckboxSliderTemplate"},
+            --{name = "ButtonsNumber", template = "OptionsCheckboxSliderTemplate"},
+            --{name = "ButtonSize", template = "OptionsDoubleCheckboxSliderTemplate"},
             {name = "BarsPadding", template = "OptionsCheckboxSliderTemplate"},
+        }
+    },
+    --[[ {
+        name = "BarsPagingContainer",
+        childs = {
+            {name = "BarGrow", template = "OptionsDropdownTemplate"},
         }
     }, ]]
 }
@@ -393,9 +401,12 @@ Addon.EssentialCooldownViewer = {
     {
         name = "ColorOverrideOptionsContainer",
         childs = {
+            {name = "CustomColorOnNormal", template = "OptionsColorOverrideTemplate"},
             {name = "CustomColorOOR", template = "OptionsColorOverrideTemplate"},
             {name = "CustomColorOOM", template = "OptionsColorOverrideTemplate"},
             {name = "CustomColorNotUsable", template = "OptionsColorOverrideTemplate"},
+            --{name = "CustomColorOnGCD", template = "OptionsColorOverrideTemplate"},
+            {name = "CustomColorOnActualCD", template = "OptionsColorOverrideTemplate"},
         }
     },
 }
@@ -406,8 +417,6 @@ Addon.BuffIconCooldownViewer = {
             {name = "CDMEnable", template = "OptionsCheckboxTemplate"},
             {name = "IconPadding", template = "OptionsCheckboxSliderTemplate"},
             {name = "CenteredGrid", template = "OptionsCheckboxTemplate"},
-            {name = "RemovePandemicAnims", template = "OptionsCheckboxTemplate"},
-            {name = "RemoveDesaturation", template = "OptionsCheckboxTemplate"},
         }
     },
     {
@@ -455,16 +464,6 @@ Addon.BuffIconCooldownViewer = {
         childs = {
             {name = "BackdropSize", template = "OptionsCheckboxSliderTemplate"},
             {name = "BackdropColor", template = "OptionsColorOverrideTemplate"},
-            {name = "BackdropAuraColor", template = "OptionsColorOverrideTemplate"},
-            {name = "BackdropPandemicColor", template = "OptionsColorOverrideTemplate"},
-        }
-    },
-    {
-        name = "ColorOverrideOptionsContainer",
-        childs = {
-            {name = "CustomColorOOR", template = "OptionsColorOverrideTemplate"},
-            {name = "CustomColorOOM", template = "OptionsColorOverrideTemplate"},
-            {name = "CustomColorNotUsable", template = "OptionsColorOverrideTemplate"},
         }
     },
 }
@@ -475,6 +474,7 @@ Addon.BuffBarCooldownViewer = {
             {name = "CDMEnable", template = "OptionsCheckboxTemplate"},
             {name = "IconPadding", template = "OptionsCheckboxSliderTemplate"},
             {name = "RemovePandemicAnims", template = "OptionsCheckboxTemplate"},
+            {name = "RemoveAuraTypeBorder", template = "OptionsCheckboxTemplate"},
         }
     },
     {


### PR DESCRIPTION
# 2.1.0 What's New

- Added **centered layout** for action bars
- Added **padding control** for action bars
- Added **growth direction** setting for action bars
- Added **custom color for Normal state** of icons in Cooldown Viewer
- Added **custom color for icons On Cooldown** in Cooldown Viewer
- Added option to **remove debuff border** from BuffBar
- Fixed **fading** logic and activation
- **GCD swipe** can now be disabled on Retail
- Fixed various **localization strings**
- Fixed **glow color preview** for Cooldown Viewer frames
- Fixed **BuffBars color swatches**
- Removed **border from preview** of Cooldown Viewer frames
- Removed **unusable options** for specific frame types