### PR TITLE
v2.1.4

### DIFF
--- a/ActionBarsEnhanced.toc
+++ b/ActionBarsEnhanced.toc
@@ -2,7 +2,7 @@
 ## Title: |cFF30D1FFActionBars Enhanced|r (Retail | Beta)
 ## IconTexture: Interface\AddOns\ActionBarsEnhanced\assets\icon
 ## Category: Action Bars
-## Version: 2.1.3
+## Version: 2.1.4
 ## SavedVariables: ABDB
 ## Notes: Enhance Blizzard Action Bars
 ## Notes-ruRU: Улучшение стандартных панелей заклинаний

--- a/CooldownManagerViewer.lua
+++ b/CooldownManagerViewer.lua
@@ -157,8 +157,15 @@ local function Hook_CooldownFrame_Set(self)
             if Addon:GetValue("UseCDMBackdrop", nil, barName) then
                 SetBorderColor(button, {Addon:GetRGBA("CDMBackdropColor", nil, barName)}, "reset")
             end
-                
-                --[[ if (button.isOnGCD and not button.isOnActualCooldown) and Addon:GetValue("CDMRemoveGCDSwipe", nil, barName) then
+            
+            if not isBeta then
+                local spellID = button:GetSpellID()
+                button.__isOnGCD, button.__isOnActualCooldown = Addon:IsSpellOnGCD(spellID)
+                if (button.__isOnGCD and not button.__isOnActualCooldown) and Addon:GetValue("CDMRemoveGCDSwipe", nil, barName) then
+                    button.Cooldown:SetSwipeColor(0,0,0,0)
+                end
+            else
+                if (button.isOnGCD and not button.isOnActualCooldown) and Addon:GetValue("CDMRemoveGCDSwipe", nil, barName) then
                     button.Cooldown:Hide()
                 end
                 if (button.isOnGCD and not button.isOnActualCooldown) then
@@ -167,32 +174,12 @@ local function Hook_CooldownFrame_Set(self)
                     if not button.wasSetFromCharges then
                         button.__isOnActualCooldown = true
                     else
-                         button.__isOnActualCooldown = false
+                        button.__isOnActualCooldown = false
                     end
-                end ]]
-
-            button.Cooldown:SetReverse(Addon:GetValue("CDMReverseSwipe", nil, barName))
-        end
-
-        if not isBeta then
-            local spellID = button:GetSpellID()
-            button.__isOnGCD, button.__isOnActualCooldown = Addon:IsSpellOnGCD(spellID)
-            if (button.__isOnGCD and not button.__isOnActualCooldown) and Addon:GetValue("CDMRemoveGCDSwipe", nil, barName) then
-                button.Cooldown:SetSwipeColor(0,0,0,0)
-            end
-        else
-            if (button.isOnGCD and not button.isOnActualCooldown) and Addon:GetValue("CDMRemoveGCDSwipe", nil, barName) then
-                button.Cooldown:Hide()
-            end
-            if (button.isOnGCD and not button.isOnActualCooldown) then
-                button.__isOnGCD = true
-            else
-                if not button.wasSetFromCharges then
-                    button.__isOnActualCooldown = true
-                else
-                    button.__isOnActualCooldown = false
                 end
             end
+
+            button.Cooldown:SetReverse(Addon:GetValue("CDMReverseSwipe", nil, barName))
         end
 
         button.Cooldown:SetCountdownAbbrevThreshold(620)

--- a/ProfileImportExport.lua
+++ b/ProfileImportExport.lua
@@ -480,3 +480,11 @@ function ActionBarsEnhancedProfilesMixin:GetProfiles()
 
     return profileTbl
 end
+
+function ABE_ImportProfile(profileName, profileString, shouldSet)
+    return ActionBarsEnhancedImportDialogMixin:AcceptImport(_, profileString, profileName, shouldSet)
+end
+
+function ABE_GetProfiles()
+    return ActionBarsEnhancedProfilesMixin:GetProfiles()
+end


### PR DESCRIPTION
# v2.1.4

- Added global function **`ABE_ImportProfile`** to import ABE profiles from other addons (e.g. UI or profile installers). **Usage:** `success = ABE_ImportProfile(profileName, profileString, shouldSet)`
  - `shouldSet` (boolean): whether to activate the imported profile immediately.
  - Returns `true` if the import succeeded, `false` otherwise.

- Added global function **`ABE_GetProfiles()`** that returns a sorted table of profile names in the format `[index] = "ProfileName"`.