### PR TITLE
GameTooltip shrink fix

### DIFF
--- a/ActionBarsEnhanced_AdvancedMenu.lua
+++ b/ActionBarsEnhanced_AdvancedMenu.lua
@@ -490,6 +490,7 @@ function ABE_BarsListMixin:InitButtons(buttons, frame)
             GameTooltip:Show()
         end)
         button.Paste:SetScript("OnLeave",function(self)
+            GameTooltip:SetScale(1)
             GameTooltip:Hide()
         end)
         

--- a/BlizzFixesAndTweaks.lua
+++ b/BlizzFixesAndTweaks.lua
@@ -133,6 +133,7 @@ local function ShowAnchorIcon(self)
             GameTooltip:Show()
         end)
         self.__anchorIcon:SetScript("OnLeave",function(icon)
+            GameTooltip:SetScale(1)
             GameTooltip:Hide()
         end)
     end


### PR DESCRIPTION
Fix GameTooltip shrinking when mousing over copy icon in Advanced menu. Resolves #47.